### PR TITLE
Move trigger page from show property to setupEvents.

### DIFF
--- a/jquery.twbsPagination.js
+++ b/jquery.twbsPagination.js
@@ -100,7 +100,6 @@
             this.render(this.getPages(page));
             this.setupEvents();
 
-            this.$element.trigger('page', page);
 
             return this;
         },
@@ -236,7 +235,11 @@
                 }
                 // Prevent click event if href is not set.
                 !_this.options.href && evt.preventDefault();
-                _this.show(parseInt($this.data('page')));
+
+                var page = $this.data('page');
+                $this.trigger('page', page);
+
+                _this.show(parseInt(page));
             });
         },
 


### PR DESCRIPTION
In our project we use server side paging, many times we want to disable paging because there is unsaved data in the view. Using your code as was we had a minor problem when we should block the navigation.
By clicking the navigate button ('next','last', etc.) the UI was updating but our "logic" was blocking the navigation. So, the paginator control was changing pageNo but not regarding data from our server side paging.
We moved the trigger event of page outside show function to setupEvents. 

We propose to expose two properties like onPageClick, for example onPageChanging and onPageChanged.
**onPageChanging**: will contains all the "logic" that must be executed before make any changes in UI
**onPageChanged**: will run after _onPageChanging_ and basically will just update the UI.