### PR TITLE
'href' not working

### DIFF
--- a/jquery.twbsPagination.js
+++ b/jquery.twbsPagination.js
@@ -265,7 +265,11 @@
         generateQueryString: function (pageNumber, searchStr) {
             var search = this.getSearchString(searchStr),
                 regex = new RegExp(this.options.pageVariable + '=*[^&#]*');
-            if (!search) return '';
+            
+            // 'href' working
+            if (!search) search = this.options.pageVariable+"=1";
+            else if(!regex.test(search)) search += "&" + this.options.pageVariable+"=1";
+            
             return '?' + search.replace(regex, this.options.pageVariable + '=' + pageNumber);
 
         },


### PR DESCRIPTION
在开启  'href' 属性后，并不能正常工作，这样修改后，就可以正常工作了。